### PR TITLE
Add share links for pastes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# UkrPaste
+
+UkrPaste is a collection of funny Ukrainian Twitch pastes hosted as a static site on Netlify.
+
+The site itself is completely static and all dynamic logic runs in the browser. Netlify Functions are used only to forward submissions to a Discord webhook.
+
+## Local development
+
+1. Install dependencies (only used for the development server):
+   ```bash
+   npm install
+   ```
+2. Start a local server:
+   ```bash
+   npm start
+   ```
+   This serves the project on `http://localhost:3000` using the `serve` package.
+
+### Python helpers
+
+`app.py` and `handler.py` are small scripts used locally to maintain `pastes.json`:
+
+- **handler.py** parses `input_pastes.txt` and saves cleaned pastes to `new_pastes.json`.
+- **app.py** provides a tiny Flask interface for previewing `pastes.json` and adding new entries.
+
+These utilities are not used on Netlify but can speed up manual updates of the JSON files.
+
+## Sharing pastes
+
+Every paste has its own link accessible via the new Share button. It opens `paste.html` with the paste index in the hash (e.g. `paste.html#5`). You can copy or share this link directly.
+
+## Environment variables
+
+The Netlify function in `netlify/functions/form.js` expects a `WEBHOOK_URL` environment variable with a Discord webhook address.
+

--- a/index.jsx
+++ b/index.jsx
@@ -159,13 +159,13 @@ function IndexPage() {
                       className="flex items-center text-sm text-gray-600 dark:text-gray-300 hover:text-black dark:hover:text-white"
                       onClick={() => handleCopy(paste.text)}
                     >
-                      <i className="p-1 fa-solid fa-clone"></i> Копіювати
+                      <i className="p-1 fa-solid fa-clone"></i>
                     </button>
                     <button
                       className="flex items-center text-sm text-gray-600 dark:text-gray-300 hover:text-black dark:hover:text-white"
                       onClick={() => sharePaste(idx, paste)}
                     >
-                      <i className="p-1 fa-solid fa-share-nodes"></i> Поділитись
+                      <i className="p-1 fa-solid fa-share-nodes"></i>
                     </button>
                     <button
                       className={`text-sm ${fav ? 'text-pink-600' : 'text-gray-600 dark:text-gray-300'} hover:text-pink-700`}

--- a/index.jsx
+++ b/index.jsx
@@ -46,6 +46,18 @@ function IndexPage() {
     localStorage.setItem('copyHistory', JSON.stringify(history));
   };
 
+  const sharePaste = (id, paste) => {
+    const url = `${window.location.origin}/paste.html#${id}`;
+    if (navigator.share) {
+      navigator
+        .share({ title: 'УкрПаста', text: paste.text, url })
+        .catch(() => {});
+    } else {
+      navigator.clipboard.writeText(url);
+      alert('Посилання скопійовано!');
+    }
+  };
+
   const toggleFavorite = paste => {
     setFavorites(prev => {
       const exists = prev.some(
@@ -148,6 +160,12 @@ function IndexPage() {
                       onClick={() => handleCopy(paste.text)}
                     >
                       <i className="p-1 fa-solid fa-clone"></i> Копіювати
+                    </button>
+                    <button
+                      className="flex items-center text-sm text-gray-600 dark:text-gray-300 hover:text-black dark:hover:text-white"
+                      onClick={() => sharePaste(idx, paste)}
+                    >
+                      <i className="p-1 fa-solid fa-share-nodes"></i> Поділитись
                     </button>
                     <button
                       className={`text-sm ${fav ? 'text-pink-600' : 'text-gray-600 dark:text-gray-300'} hover:text-pink-700`}

--- a/paste.html
+++ b/paste.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Паста | УкрПаста</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: 'class' };
+  </script>
+  <script src="https://kit.fontawesome.com/a0ff110df7.js" crossorigin="anonymous"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="min-h-screen flex flex-col bg-gray-100 text-black dark:bg-gray-900 dark:text-white">
+  <div id="root" class="flex-grow"></div>
+  <script type="text/babel" src="components.jsx"></script>
+  <script type="text/babel" src="paste.jsx"></script>
+</body>
+</html>

--- a/paste.jsx
+++ b/paste.jsx
@@ -1,0 +1,59 @@
+function PastePage() {
+  const [paste, setPaste] = React.useState(null);
+  const [notFound, setNotFound] = React.useState(false);
+
+  React.useEffect(() => {
+    fetch('pastes.json')
+      .then(res => res.json())
+      .then(data => {
+        const id = window.location.hash.slice(1);
+        const idx = parseInt(id, 10);
+        if (!isNaN(idx) && data[idx]) {
+          setPaste({ ...data[idx], idx });
+        } else {
+          setNotFound(true);
+        }
+      })
+      .catch(() => setNotFound(true));
+  }, []);
+
+  const copyPaste = text => {
+    navigator.clipboard.writeText(text);
+  };
+
+  if (notFound) {
+    return (
+      <div className="flex flex-col min-h-screen">
+        <Header />
+        <main className="flex-grow flex items-center justify-center p-6">
+          <p className="text-xl">Пасту не знайдено.</p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (!paste) return null;
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-grow flex flex-col items-center p-6">
+        <h2 className="text-3xl font-bold mb-4">Паста #{paste.idx + 1}</h2>
+        <div className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md p-6 max-w-2xl w-full">
+          <p className="mb-4 whitespace-pre-wrap break-words">{paste.text}</p>
+          <p className="text-right text-sm text-gray-500 mb-4">— {paste.author}</p>
+          <button
+            className="bg-pink-700 hover:bg-pink-600 text-white px-4 py-2 rounded-md"
+            onClick={() => copyPaste(paste.text)}
+          >
+            <i className="fa-solid fa-copy mr-1"></i> Копіювати
+          </button>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<PastePage />);


### PR DESCRIPTION
## Summary
- remove tags field from the submission form and webhook
- introduce a new `paste.html` page to display a single paste
- add a Share button for each paste that copies or shares a link
- document how to use shareable links

## Testing
- `npm test` *(fails: Missing script and no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6856c0c71320833284768c225642a3ed