### PR TITLE
Expand API with tag filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ Every paste has its own link accessible via the new Share button. It opens `past
 
 The Netlify function in `netlify/functions/form.js` expects a `WEBHOOK_URL` environment variable with a Discord webhook address.
 
+## API
+
+The site exposes a small API powered by Netlify Functions. You can fetch pastes in JSON format using the following endpoints:
+
+- `/.netlify/functions/api` – return all pastes.
+- `/.netlify/functions/api?id=0` – return a paste by index.
+- `/.netlify/functions/api?random=1` – return a random paste.
+- `/.netlify/functions/api?tag=Вибачення` – return all pastes with a tag.
+- `/.netlify/functions/api?tag=Вибачення&random=1` – random paste from that tag.
+

--- a/api.html
+++ b/api.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>API | УкрПаста</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: 'class' };
+  </script>
+  <script src="https://kit.fontawesome.com/a0ff110df7.js" crossorigin="anonymous"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="min-h-screen flex flex-col bg-gray-100 text-black dark:bg-gray-900 dark:text-white">
+  <div id="root" class="flex-grow"></div>
+  <script type="text/babel" src="components.jsx"></script>
+  <script type="text/babel" src="api.jsx"></script>
+</body>
+</html>

--- a/api.jsx
+++ b/api.jsx
@@ -1,0 +1,22 @@
+function APIPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main className="flex-grow flex flex-col items-center p-6 max-w-4xl mx-auto text-left">
+        <h2 className="text-4xl font-bold mb-6">API</h2>
+        <p className="mb-4">Невеликий API дозволяє отримувати пасти у форматі JSON.</p>
+        <ul className="list-disc pl-6 mb-4">
+          <li><code>/.netlify/functions/api</code> — усі пасти</li>
+          <li><code>/.netlify/functions/api?random=1</code> — випадкова паста</li>
+          <li><code>/.netlify/functions/api?id=0</code> — паста за індексом</li>
+          <li><code>/.netlify/functions/api?tag=Вибачення</code> — усі пасти з тегом</li>
+          <li><code>/.netlify/functions/api?tag=Вибачення&random=1</code> — випадкова паста з цього тегу</li>
+        </ul>
+        <p className="text-sm text-gray-500">Індекси відповідають порядку у <code>pastes.json</code>.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<APIPage />);

--- a/components.jsx
+++ b/components.jsx
@@ -43,6 +43,9 @@ function Header() {
       <a href="favorites" className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-md text-sm flex items-center gap-2">
         <i className="fas fa-heart"></i> Улюблені
       </a>
+      <a href="api" className="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded-md text-sm flex items-center gap-2">
+        <i className="fas fa-code"></i> API
+      </a>
       <button
         onClick={toggleTheme}
         className="w-[35px] h-[35px] bg-gray-700 hover:bg-gray-600 text-white p-2 rounded-md text-sm"

--- a/netlify/functions/api.js
+++ b/netlify/functions/api.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+
+exports.handler = async function(event) {
+  const filePath = path.join(__dirname, '..', 'pastes.json');
+  const pastes = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const params = event.queryStringParameters || {};
+
+  if (params.id !== undefined) {
+    const index = parseInt(params.id, 10);
+    if (!isNaN(index) && index >= 0 && index < pastes.length) {
+      return {
+        statusCode: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(pastes[index]),
+      };
+    }
+    return {
+      statusCode: 404,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Paste not found' }),
+    };
+  }
+
+  // filter by tag if provided
+  let list = pastes;
+  if (params.tag !== undefined) {
+    list = pastes.filter((p) => Array.isArray(p.tags) && p.tags.includes(params.tag));
+  }
+
+  // return random paste (optionally within tag subset)
+  if (params.random !== undefined) {
+    if (list.length === 0) {
+      return {
+        statusCode: 404,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'Paste not found' }),
+      };
+    }
+    const random = list[Math.floor(Math.random() * list.length)];
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(random),
+    };
+  }
+
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(list),
+  };
+};


### PR DESCRIPTION
## Summary
- add ability to filter pastes by tag and return a random item from that set
- document the tag filter in README
- list the new API options on the API page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856c42986088332b266eda58e2bdfee