### PR TITLE
Add nonl option to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ The site exposes a small API powered by Netlify Functions. You can fetch pastes 
 - `/.netlify/functions/api?random=1&textonly=1` – just the text of a random paste.
 - `/.netlify/functions/api?random=1&textonly=1&plain=1` – plain text without JSON.
 - `/.netlify/functions/api?random=1&max=500` – limit text to 500 characters.
+- `/.netlify/functions/api?random=1&nonl=1` – replace newlines with spaces.
 
-Add `textonly=1` to return only the text in JSON. Use `plain=1` together with `textonly=1` to get raw text without the `{"text":...}` wrapper. You can also pass `max=<number>` to truncate the returned text to a specific length.
+Add `textonly=1` to return only the text in JSON. Use `plain=1` together with `textonly=1` to get raw text without the `{"text":...}` wrapper. You can also pass `max=<number>` to truncate the returned text to a specific length. Set `nonl=1` to strip line breaks and replace them with spaces (useful for Twitch chats).
 
 ### Використання зі StreamElements
 

--- a/api.jsx
+++ b/api.jsx
@@ -14,6 +14,7 @@ function APIPage() {
           <li><code>/.netlify/functions/api?random=1&textonly=1</code> — тільки текст випадкової пасти</li>
           <li><code>/.netlify/functions/api?random=1&textonly=1&plain=1</code> — повернути лише сам текст</li>
           <li><code>/.netlify/functions/api?random=1&max=500</code> — обрізати текст до 500 символів</li>
+          <li><code>/.netlify/functions/api?random=1&nonl=1</code> — замінити перенос рядка на пробіл</li>
         </ul>
         <h3 className="text-2xl font-semibold mb-2">Приклади</h3>
         <pre className="bg-gray-800 text-green-400 p-4 rounded mb-2 whitespace-pre-wrap">
@@ -21,6 +22,9 @@ curl https://ukrpaste.netlify.app/.netlify/functions/api?random=1
         </pre>
         <pre className="bg-gray-800 text-green-400 p-4 rounded mb-2 whitespace-pre-wrap">
 curl https://ukrpaste.netlify.app/.netlify/functions/api?random=1&textonly=1&plain=1&max=500
+        </pre>
+        <pre className="bg-gray-800 text-green-400 p-4 rounded mb-2 whitespace-pre-wrap">
+curl https://ukrpaste.netlify.app/.netlify/functions/api?random=1&nonl=1
         </pre>
         <pre className="bg-gray-800 text-green-400 p-4 rounded mb-4 whitespace-pre-wrap">
 curl "https://ukrpaste.netlify.app/.netlify/functions/api?tag=\u0412\u0438\u0431\u0430\u0447\u0435\u043d\u043d\u044f"

--- a/netlify/functions/api.js
+++ b/netlify/functions/api.js
@@ -5,6 +5,7 @@ exports.handler = async function(event) {
   const textOnly = params.textonly !== undefined;
   const plain = params.plain !== undefined;
   const max = params.max !== undefined ? parseInt(params.max, 10) : null;
+  const removeNewlines = params.nonl !== undefined;
 
   const limitText = (text) => {
     if (max !== null && !isNaN(max) && max > 0) {
@@ -13,11 +14,19 @@ exports.handler = async function(event) {
     return text;
   };
 
+  const formatText = (text) => {
+    let result = limitText(text);
+    if (removeNewlines) {
+      result = result.replace(/\n/g, ' ');
+    }
+    return result;
+  };
+
   if (params.id !== undefined) {
     const index = parseInt(params.id, 10);
     if (!isNaN(index) && index >= 0 && index < pastes.length) {
       const paste = pastes[index];
-      const text = limitText(paste.text);
+      const text = formatText(paste.text);
       const body = textOnly
         ? plain
           ? text
@@ -52,7 +61,7 @@ exports.handler = async function(event) {
       };
     }
     const random = list[Math.floor(Math.random() * list.length)];
-    const text = limitText(random.text);
+    const text = formatText(random.text);
     const body = textOnly
       ? plain
         ? text
@@ -67,9 +76,9 @@ exports.handler = async function(event) {
 
   const result = textOnly
     ? plain
-      ? list.map((p) => limitText(p.text))
-      : list.map((p) => ({ text: limitText(p.text) }))
-    : list.map((p) => ({ ...p, text: limitText(p.text) }));
+      ? list.map((p) => formatText(p.text))
+      : list.map((p) => ({ text: formatText(p.text) }))
+    : list.map((p) => ({ ...p, text: formatText(p.text) }));
   return {
     statusCode: 200,
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- add `nonl` API parameter to replace newlines with spaces
- document the new option in README and api page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856d1fddb408332bb5cfc4968ca5100